### PR TITLE
Add reusable supplier select style

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             border: 1px solid #e5e7eb;
         }
         /* Estilos para select de fornecedores com barra de rolagem */
-        #product-supplier {
+        .supplier-select {
             max-height: 120px;
             overflow-y: auto;
         }
@@ -131,7 +131,7 @@
                         <h2 class="text-lg font-semibold mb-4 text-gray-700">Adicionar Produto ao Estoque</h2>
                         <form id="add-item-form" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                             <input type="text" id="product-name" placeholder="Nome do Produto" class="sm:col-span-2 shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" required>
-                            <select id="product-supplier" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 bg-white max-h-32 overflow-y-auto">
+                            <select id="product-supplier" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 bg-white supplier-select">
                                 <option value="">Selecione um fornecedor</option>
                             </select>
                             <input type="number" id="product-quantity" placeholder="Qtd. Atual" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700" step="any" required>
@@ -146,7 +146,7 @@
                     <div class="bg-white p-6 rounded-xl shadow-lg">
                         <div class="flex justify-between items-center mb-4">
                             <h2 class="text-lg font-semibold text-gray-700">Itens no Estoque</h2>
-                            <select id="supplier-filter" class="shadow-sm appearance-none border rounded py-2 px-3 text-gray-700 bg-white text-sm"></select>
+                            <select id="supplier-filter" class="supplier-select shadow-sm appearance-none border rounded py-2 px-3 text-gray-700 bg-white text-sm"></select>
                         </div>
                         <div id="stock-list" class="space-y-3"></div>
                     </div>


### PR DESCRIPTION
## Summary
- create `.supplier-select` CSS class
- remove old `#product-supplier` rule
- use `.supplier-select` class for product and filter dropdowns

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685b04847a20832e8c7e4f00da6c7004