### PR TITLE
Fix supplier filter names in shopping list

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,12 @@
 
            slFilter.innerHTML = `
                 <option value="TODOS">Todos os fornecedores</option>
-                ${appState.suppliers.map(supplier => `<option value="${escapeHtml(supplier.nome)}">${escapeHtml(supplier.nome)}</option>`).join('')}
+                ${appState.suppliers
+                    .map(s => {
+                        const label = escapeHtml(s.nome || s.name || '');
+                        return `<option value="${label}">${label}</option>`;
+                    })
+                    .join('')}
            `;
            slFilter.size = Math.min(appState.suppliers.length + 1, 5);
        }


### PR DESCRIPTION
## Summary
- support suppliers that use either `nome` or `name` in `updateShoppingListSupplierFilter`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bd364476c832e8cf41e7a2e150faa