### PR TITLE
Add Firebase log exclusions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ pnpm-debug.log*
 .env
 .env.*
 
+# Firebase CLI files
+.firebase/
+firebase-debug.log*
+firestore-debug.log*
+
 # Coverage directory
 coverage/
 


### PR DESCRIPTION
## Summary
- extend the `.gitignore` with Firebase-specific patterns so temporary CLI files aren't committed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685beb35eb64832e86dbe4892e97773e