### PR TITLE
Fix balance UI and missing date format

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
             scroll-behavior: smooth;
         }
 
+        .balanco-scroll {
+            max-height: 500px;
+            overflow-y: auto;
+            scroll-behavior: smooth;
+        }
+
         }
     </style>
 </head>
@@ -343,6 +349,34 @@
                             <button data-view="novo" class="balance-view-button bg-blue-500 text-white px-2 py-1 rounded text-sm">Realizar Balanço</button>
                             <button data-view="historico" class="balance-view-button bg-gray-200 px-2 py-1 rounded text-sm">Histórico de Balanços</button>
                         </div>
+                        <div id="balance-new-view">
+                            <div class="flex justify-between mb-2">
+                                <div class="space-x-2">
+                                    <button class="balance-group-button bg-blue-500 text-white px-2 py-1 rounded text-sm" data-bgroup="fornecedor">Por Fornecedor</button>
+                                    <button class="balance-group-button bg-gray-200 px-2 py-1 rounded text-sm" data-bgroup="cozinha">Produção Cozinha</button>
+                                    <button class="balance-group-button bg-gray-200 px-2 py-1 rounded text-sm" data-bgroup="parrilla">Produção Parrilla</button>
+                                </div>
+                                <div class="space-x-2">
+                                    <button id="balance-summary-btn" class="bg-gray-500 text-white px-2 py-1 rounded text-sm">Resumo</button>
+                                    <button id="apply-balance-btn" class="bg-green-600 text-white px-2 py-1 rounded text-sm" disabled>Aplicar Balanço</button>
+                                    <button id="balance-pdf-btn" class="bg-gray-600 text-white px-2 py-1 rounded text-sm">Exportar PDF</button>
+                                </div>
+                            </div>
+                            <div id="balance-table-container" class="balanco-scroll"></div>
+                            <div id="balance-summary" class="mt-4"></div>
+                        </div>
+                        <div id="balance-history-view" class="hidden">
+                            <div class="flex gap-2 mb-2">
+                                <input type="month" id="history-date-filter" class="border rounded p-1 text-sm">
+                                <select id="history-type-filter" class="border rounded p-1 text-sm">
+                                    <option value="">Todos</option>
+                                    <option value="fornecedor">Por Fornecedor</option>
+                                    <option value="cozinha">Produção Cozinha</option>
+                                    <option value="parrilla">Produção Parrilla</option>
+                                </select>
+                            </div>
+                            <div id="balance-history-list" class="balanco-scroll"></div>
+                        </div>
 
                     </div>
                 </div>
@@ -525,6 +559,17 @@
         function formatDateISO(date){
             const [day, month, year] = new Date(date).toLocaleDateString('pt-BR').split('/');
             return `${year}-${month}-${day}`;
+        }
+
+        function formatDateTimeBR(date) {
+            const d = new Date(date);
+            return d.toLocaleString('pt-BR', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+            });
         }
 
         }


### PR DESCRIPTION
## Summary
- add markup for balance view including containers used by scripts
- add CSS helper class for scrollable balance sections
- implement `formatDateTimeBR` helper for readability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861b32ba604832ebf90652b3a7e59c6