### PR TITLE
fix production quantity update

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
         import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-        import { getFirestore, collection, doc, onSnapshot, addDoc, deleteDoc, updateDoc, setDoc, getDocs, query, where, collectionGroup, getDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { getFirestore, collection, doc, onSnapshot, addDoc, deleteDoc, updateDoc, setDoc, getDocs, query, where, collectionGroup, increment } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
         const firebaseConfig = {
             apiKey: "AIzaSyBJbyfICQFEfzL7EKbaH-08mQmZWOM8FhU",
@@ -1859,22 +1859,20 @@ function renderProductionList() {
             const input = document.querySelector(`input[data-item-id="${id}"]`);
             if (!input) return;
 
-            const increment = parseFloat(input.value);
-            if (isNaN(increment)) {
+            const delta = parseFloat(input.value);
+            if (isNaN(delta)) {
                 showMessage('Quantidade inválida', true);
                 return;
             }
 
             try {
                 const ref = doc(db, 'producao', id);
-                const snap = await getDoc(ref);
-                const atual = snap.exists() ? (snap.data().quantidade || 0) : 0;
                 await updateDoc(ref, {
-                    quantidade: atual + increment,
+                    quantidade: increment(delta),
                     timestamp: new Date().toISOString()
                 });
                 await addDoc(collection(ref, 'historicoInclusoes'), {
-                    quantidade: increment,
+                    quantidade: delta,
                     dataHora: new Date().toISOString()
                 });
                 showMessage('Produção registrada com sucesso!');


### PR DESCRIPTION
## Summary
- import `increment` from Firestore
- update production quantity using atomic increment

## Testing
- `npm --version`
- `npx serve -v` *(fails: access denied)*

------
https://chatgpt.com/codex/tasks/task_e_6861c24d1104832ebba0c4b8f642e8ad