### PR TITLE
Fix balance table responsiveness on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,16 @@
             padding-right: 8px;
             padding-left: 4px;
         }
+
+        .tabela-responsiva {
+            width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .tabela-responsiva table {
+            min-width: 800px;
+        }
     </style>
 </head>
 <body class="bg-gray-100">
@@ -1075,7 +1085,10 @@ function renderProductionList() {
            });
            const wrapper = document.createElement('div');
            wrapper.className = 'balanco-scroll';
-           wrapper.appendChild(table);
+           const responsive = document.createElement('div');
+           responsive.className = 'tabela-responsiva';
+           responsive.appendChild(table);
+           wrapper.appendChild(responsive);
            balanceTableContainer.appendChild(wrapper);
            checkBalanceInputs();
        }


### PR DESCRIPTION
## Summary
- add horizontal scrolling style for balance tables via `.tabela-responsiva`
- wrap balance tables with responsive container in JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d61a7004832e9370068161702694