### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
     <style>
+        html, body {
+            overflow-x: hidden;
+        }
         .tab-button.active {
             border-color: #3b82f6;
             color: #3b82f6;
@@ -88,7 +91,7 @@
         .balanco-tabela-container {
             width: 100%;
             max-width: 100%;
-            overflow-x: auto;
+            overflow-x: hidden;
         }
 
         .balanco-tabela-container table {
@@ -97,6 +100,7 @@
             table-layout: fixed;
             border-collapse: collapse;
             font-size: 14px;
+            word-break: break-word;
         }
 
         .balanco-tabela-container th,
@@ -378,7 +382,7 @@
                             <div>
                                 <h3 class="font-semibold text-gray-700 mb-2">Ingredientes</h3>
                                 <datalist id="ingredientes-options"></datalist>
-                                <div class="grid grid-cols-8 gap-2 font-semibold text-sm mb-1">
+                                <div class="grid grid-cols-4 sm:grid-cols-8 gap-2 font-semibold text-sm mb-1">
                                     <span>Ingrediente</span>
                                     <span>Qtd. Líquida</span>
                                     <span>Unidade</span>
@@ -845,7 +849,7 @@
 
         function addIngredienteRow(data = {}) {
             const row = document.createElement('div');
-            row.className = 'grid grid-cols-8 gap-2 items-center text-sm';
+            row.className = 'grid grid-cols-4 sm:grid-cols-8 gap-2 items-center text-sm';
 
             const select = document.createElement('input');
             select.setAttribute('list', 'ingredientes-options');


### PR DESCRIPTION
## Summary
- hide horizontal overflow globally
- disable horizontal scroll on balance tables
- wrap text within balance tables
- reduce ingredient grid columns on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686587d53348832ebd2513f49c0b572b