### PR TITLE
Remove hardcoded superadmin credentials and document role setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,23 @@ The command prints a local URL (for example `http://localhost:3000`). Open that 
 
 ## Multi-company mode
 
-Use the credentials `admin@gestaomesa360.com` / `mesa360` to access the **superadmin** area. From there it is possible to cadastrar novas empresas e criar o usuário administrador de cada uma.
+To access the **superadmin** area the signed-in user must have `role: "superadmin"`.
+There are two ways to assign this role:
+
+1. **Custom claims** – using the Firebase Admin SDK:
+
+   ```js
+   admin.auth().setCustomUserClaims(uid, { role: 'superadmin' });
+   ```
+
+   After setting the claim, the user needs to sign out and sign in again.
+
+2. **User document** – directly in Firestore under
+   `empresas/{empresaId}/usuarios/{uid}` set the field `role` to
+   `"superadmin"`.
+
+Once the role is assigned, log in with that user's credentials to cadastrar
+novas empresas e criar o usuário administrador de cada uma.
 
 ## Usage
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function isSignedIn() { return request.auth != null; }
-    function isSuperAdmin() { return isSignedIn() && request.auth.token.email == 'admin@gestaomesa360.com'; }
+      function isSuperAdmin() { return isSignedIn() && request.auth.token.role == 'superadmin'; }
     function inCompany(empresaId) {
       return exists(/databases/$(database)/documents/empresas/$(empresaId)/usuarios/$(request.auth.uid));
     }

--- a/index.html
+++ b/index.html
@@ -543,8 +543,6 @@
         const app = initializeApp(firebaseConfig);
         const auth = getAuth(app);
         const db = getFirestore(app);
-        const SUPERADMIN_EMAIL = "admin@gestaomesa360.com";
-        const SUPERADMIN_PASSWORD = "mesa360";
         let companyPath = [];
         let userRole = 'usuario';
         let lastLoginPassword = '';
@@ -2452,7 +2450,7 @@ function renderProductionList() {
         onAuthStateChanged(auth, async (user) => {
             if (user) {
                 const role = await loadCompanyByEmail(user.email);
-                userRole = role || (user.email === SUPERADMIN_EMAIL ? 'superadmin' : 'usuario');
+                userRole = role || 'usuario';
                 document.getElementById("user-email").textContent = user.email;
                 if(userRole === 'superadmin'){
                     toggleViews('admin-view');
@@ -2528,12 +2526,13 @@ function renderProductionList() {
                 const endereco = document.getElementById('empresa-endereco').value.trim();
                 const adminEmail = document.getElementById('empresa-admin-email').value.trim();
                 const adminSenha = document.getElementById('empresa-admin-senha').value;
+                const currentEmail = auth.currentUser.email;
                 try {
                     await setDoc(doc(db,'empresas', cnpj), {razao, cnpj, endereco});
                     const cred = await createUserWithEmailAndPassword(auth, adminEmail, adminSenha);
                     await setDoc(doc(db,'empresas', cnpj, 'usuarios', cred.user.uid), {email: adminEmail, role:'admin'});
                     await signOut(auth);
-                    await signInWithEmailAndPassword(auth, SUPERADMIN_EMAIL, SUPERADMIN_PASSWORD);
+                    await signInWithEmailAndPassword(auth, currentEmail, lastLoginPassword);
                     addCompanyForm.reset();
                     loadCompanies();
                     showMessage('Empresa cadastrada');


### PR DESCRIPTION
## Summary
- Remove embedded superadmin email/password and derive userRole solely from Firestore `role`
- Update Firestore rules to check custom claim `role: "superadmin"`
- Explain how to assign `superadmin` roles via custom claims or user documents in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/appestoque/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4b6a340c832e80fd3c39ed9fca8e