### PR TITLE
Add role verification for company-less users

### DIFF
--- a/index.html
+++ b/index.html
@@ -2379,6 +2379,11 @@ function renderProductionList() {
                     if(dashboardView) dashboardView.classList.add('hidden');
                 } else {
                     const role = await loadCompanyByEmail(user.email);
+                    if (role === null) {
+                        showMessage('Nenhuma empresa encontrada. Peça ao superadmin para definir uma empresa ou verifique suas credenciais.', true);
+                        await signOut(auth);
+                        return;
+                    }
                     userRole = role || 'usuario';
                     if(userRole === 'admin') adminLinkEl.classList.remove('hidden'); else adminLinkEl.classList.add('hidden');
                     toggleViews('main-app-view');


### PR DESCRIPTION
## Summary
- Prevent initialization when user lacks company and is not superadmin
- Notify user and sign out if no company association is found

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5a6546ac832ea77ce2c7e119b643