### PR TITLE
Add SVG icons to sidebar tabs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -379,13 +379,13 @@
                 <label for="drawer-toggle" aria-label="close sidebar" class="drawer-overlay"></label>
                 <nav id="tabs-container" aria-label="Tabs">
                     <ul class="menu menu-vertical w-64 bg-base-200">
-                        <li><a data-tab="stock" class="tab-button"><i class="fa-solid fa-boxes-stacked w-5 h-5 mr-2"></i>Estoque</a></li>
-                        <li><a data-tab="production" class="tab-button"><i class="fa-solid fa-industry w-5 h-5 mr-2"></i>Produção</a></li>
-                        <li><a data-tab="reports" class="tab-button"><i class="fa-solid fa-chart-column w-5 h-5 mr-2"></i>Relatórios</a></li>
-                        <li><a data-tab="fichas" class="tab-button"><i class="fa-solid fa-file-lines w-5 h-5 mr-2"></i>Ficha Técnica</a></li>
-                        <li><a data-tab="fc" class="tab-button"><i class="fa-solid fa-tags w-5 h-5 mr-2"></i>Cadastro FC/Preços</a></li>
-                        <li><a data-tab="cmv" class="tab-button"><i class="fa-solid fa-calculator w-5 h-5 mr-2"></i>Cálculo do CMV</a></li>
-                        <li><a data-tab="balance" class="tab-button"><i class="fa-solid fa-scale-balanced w-5 h-5 mr-2"></i>Balanço de Estoque</a></li>
+                        <li><a data-tab="stock" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Estoque</a></li>
+                        <li><a data-tab="production" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="3"/><path stroke-linecap="round" stroke-linejoin="round" d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>Produção</a></li>
+                        <li><a data-tab="reports" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4 20h16M6 16v-4M10 20V8M14 20v-6M18 20v-2"/></svg>Relatórios</a></li>
+                        <li><a data-tab="fichas" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6 2h9l5 5v13a2 2 0 01-2 2H6a2 2 0 01-2-2V4a2 2 0 012-2z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6M9 16h6M9 8h6"/></svg>Ficha Técnica</a></li>
+                        <li><a data-tab="fc" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M3 3v6a1 1 0 00.293.707l9.586 9.586a1 1 0 001.414 0l6-6a1 1 0 000-1.414L10.707 2.293A1 1 0 009.999 2H3a1 1 0 00-1 1z"/></svg>Cadastro FC/Preços</a></li>
+                        <li><a data-tab="cmv" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="3" width="16" height="18" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M8 7h8M8 11h8M8 15h4m2 0h2"/></svg>Cálculo do CMV</a></li>
+                        <li><a data-tab="balance" class="tab-button"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2m0 14v2M3 7h18M6 7l-3 6a4 4 0 008 0l-3-6m10 0l-3 6a4 4 0 008 0l-3-6m-8 10h8"/></svg>Balanço de Estoque</a></li>
                     </ul>
                 </nav>
             </div>


### PR DESCRIPTION
## Summary
- replace fontawesome tab icons with inline SVG icons

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6ea7eab4832ea18db29795dd6e09