### PR TITLE
Enhance mobile visibility for supplier filter in balance tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -344,11 +344,11 @@
                         </div>
                         <div id="balance-new-view">
                             <div class="flex justify-between mb-2">
-                                <div class="space-x-2 items-center flex">
+                                <div class="flex flex-wrap items-center gap-2">
                                     <button class="balance-group-button btn btn-primary btn-sm" data-bgroup="fornecedor">Por Fornecedor</button>
                                     <button class="balance-group-button btn btn-sm bg-base-200 text-base-content" data-bgroup="cozinha">Produção Cozinha</button>
                                     <button class="balance-group-button btn btn-sm bg-base-200 text-base-content" data-bgroup="parrilla">Produção Parrilla</button>
-                                    <select id="balance-supplier-filter" class="supplier-select shadow-sm appearance-none border rounded py-1 px-2 text-base-content bg-base-100 text-sm hidden"></select>
+                                    <select id="balance-supplier-filter" class="supplier-select shadow-sm appearance-none border rounded py-1 px-2 text-base-content bg-base-100 text-sm hidden w-full sm:w-auto mt-2 sm:mt-0"></select>
                                 </div>
                                 <div class="space-x-2">
                                     <button id="balance-summary-btn" class="btn btn-secondary btn-sm">Resumo</button>


### PR DESCRIPTION
## Summary
- Allow balance tab controls to wrap and space correctly on small screens
- Make supplier dropdown full width with spacing to prevent cramped appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa66c173e8832e972e1bffc7bc4969